### PR TITLE
feat(sprint6-d): integration tests for runner and CLI

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -39,7 +39,7 @@ program
       only: options.only ?? null,
       failFast: options.failFast !== false,
       reportDir: resolve(options.reportDir),
-      includePerf: options.includePef ?? false,
+      includePerf: options.includePerf ?? false,
     };
 
     const result = await run(config);

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdirSync, rmSync, writeFileSync, existsSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import { randomUUID } from 'node:crypto';
+import { execa } from 'execa';
+
+const CLI = resolve(import.meta.dirname, '../dist/cli.js');
+const cliAvailable = existsSync(CLI);
+
+function makeProject(files: Record<string, string> = {}): string {
+  const dir = join(tmpdir(), `ats-cli-${randomUUID()}`);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'test-project', version: '1.0.0' }));
+  for (const [name, content] of Object.entries(files)) {
+    const fullPath = join(dir, name);
+    mkdirSync(join(fullPath, '..'), { recursive: true });
+    writeFileSync(fullPath, content);
+  }
+  return dir;
+}
+
+let tempDirs: string[] = [];
+
+beforeEach(() => { tempDirs = []; });
+afterEach(() => {
+  for (const d of tempDirs) rmSync(d, { recursive: true, force: true });
+});
+
+function tmpProject(files?: Record<string, string>): string {
+  const dir = makeProject(files);
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function runCli(args: string[], cwd?: string) {
+  try {
+    const result = await execa('node', [CLI, ...args], { cwd, reject: false });
+    return { exitCode: result.exitCode ?? 0, stdout: result.stdout, stderr: result.stderr };
+  } catch (err: unknown) {
+    const e = err as { exitCode?: number; stdout?: string; stderr?: string };
+    return { exitCode: e.exitCode ?? 1, stdout: e.stdout ?? '', stderr: e.stderr ?? '' };
+  }
+}
+
+describe.skipIf(!cliAvailable)('cli — basic usage', () => {
+  it('prints version with --version', async () => {
+    const { exitCode, stdout } = await runCli(['--version']);
+    expect(exitCode).toBe(0);
+    expect(stdout).toMatch(/\d+\.\d+\.\d+/);
+  });
+
+  it('prints help with --help', async () => {
+    const { exitCode, stdout } = await runCli(['--help']);
+    expect(exitCode).toBe(0);
+    expect(stdout).toMatch(/run/);
+  });
+
+  it('exits 0 on a clean project (all gates skip/pass)', async () => {
+    const dir = tmpProject();
+    const { exitCode } = await runCli(['run', dir, '--skip', 'lint,typecheck,tests,build,audit,ci-config,e2e,security'], dir);
+    expect(exitCode).toBe(0);
+  });
+});
+
+describe.skipIf(!cliAvailable)('cli — --skip flag', () => {
+  it('accepts comma-separated gate names', async () => {
+    const dir = tmpProject();
+    const { exitCode, stdout } = await runCli(['run', dir, '--skip', 'lint,typecheck,tests,build,audit,ci-config,e2e,security']);
+    expect(exitCode).toBe(0);
+    expect(stdout).toMatch(/PASS|SKIP/);
+  });
+
+  it('silently ignores invalid gate names', async () => {
+    const dir = tmpProject();
+    const { exitCode } = await runCli([
+      'run', dir,
+      '--skip', 'lint,not-a-gate,typecheck,tests,build,audit,ci-config,e2e,security',
+    ]);
+    expect(exitCode).toBe(0);
+  });
+});
+
+describe.skipIf(!cliAvailable)('cli — --only flag', () => {
+  it('runs only the specified gate', async () => {
+    const dir = tmpProject();
+    const { stdout } = await runCli(['run', dir, '--only', 'ci-config']);
+    expect(stdout).toMatch(/ci-config/i);
+    expect(stdout).not.toMatch(/performance/i);
+  }, 15000);
+
+  it('silently ignores invalid gate names in --only', async () => {
+    const dir = tmpProject();
+    const { exitCode } = await runCli(['run', dir, '--only', 'not-a-gate']);
+    expect(exitCode).toBe(0);
+  });
+});
+
+describe.skipIf(!cliAvailable)('cli — --no-fail-fast flag', () => {
+  it('is accepted without error', async () => {
+    const dir = tmpProject();
+    const { exitCode } = await runCli([
+      'run', dir,
+      '--no-fail-fast',
+      '--skip', 'lint,typecheck,tests,build,audit,ci-config,e2e,security',
+    ]);
+    expect(exitCode).toBe(0);
+  });
+});
+
+describe.skipIf(!cliAvailable)('cli — --report-dir flag', () => {
+  it('writes reports to the specified directory', async () => {
+    const dir = tmpProject();
+    const reportDir = join(tmpdir(), `ats-reports-${randomUUID()}`);
+    tempDirs.push(reportDir);
+
+    await runCli([
+      'run', dir,
+      '--report-dir', reportDir,
+      '--skip', 'lint,typecheck,tests,build,audit,ci-config,e2e,security',
+    ]);
+
+    const { readdirSync } = await import('node:fs');
+    const files = readdirSync(reportDir);
+    expect(files.some(f => f.endsWith('.json'))).toBe(true);
+    expect(files.some(f => f.endsWith('.html'))).toBe(true);
+  });
+});
+
+describe.skipIf(!cliAvailable)('cli — exit codes', () => {
+  it('exits 0 for PASS', async () => {
+    const dir = tmpProject();
+    const { exitCode } = await runCli([
+      'run', dir,
+      '--skip', 'lint,typecheck,tests,build,audit,ci-config,e2e,security',
+    ]);
+    expect(exitCode).toBe(0);
+  });
+
+  it('exits 1 for unknown command', async () => {
+    const { exitCode } = await runCli(['unknown-command']);
+    expect(exitCode).toBe(1);
+  });
+});

--- a/tests/runner.test.ts
+++ b/tests/runner.test.ts
@@ -1,0 +1,258 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { randomUUID } from 'node:crypto';
+import type { GateResult, RunConfig } from '../src/types.js';
+
+vi.mock('../src/detectors/index.js', () => ({
+  detectProject: vi.fn(() => ({ rootPath: '/tmp/fake', types: ['nodejs'], packageManager: 'npm' })),
+}));
+
+vi.mock('../src/reporters/console.js', () => ({ printConsoleReport: vi.fn() }));
+vi.mock('../src/reporters/json.js', () => ({ writeJsonReport: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('../src/reporters/html.js', () => ({ writeHtmlReport: vi.fn().mockResolvedValue(undefined) }));
+
+const gateNames = ['lint', 'typecheck', 'tests', 'build', 'audit', 'ci-config', 'e2e', 'security', 'performance'];
+
+vi.mock('../src/gates/lint.js', () => ({ runLint: vi.fn() }));
+vi.mock('../src/gates/typecheck.js', () => ({ runTypecheck: vi.fn() }));
+vi.mock('../src/gates/tests.js', () => ({ runTests: vi.fn() }));
+vi.mock('../src/gates/build.js', () => ({ runBuild: vi.fn() }));
+vi.mock('../src/gates/audit.js', () => ({ runAudit: vi.fn() }));
+vi.mock('../src/gates/ci-config.js', () => ({ runCiConfig: vi.fn() }));
+vi.mock('../src/gates/e2e.js', () => ({ runE2e: vi.fn() }));
+vi.mock('../src/gates/security.js', () => ({ runSecurity: vi.fn() }));
+vi.mock('../src/gates/performance.js', () => ({ runPerformance: vi.fn() }));
+
+const { runLint } = await import('../src/gates/lint.js');
+const { runTypecheck } = await import('../src/gates/typecheck.js');
+const { runTests } = await import('../src/gates/tests.js');
+const { runBuild } = await import('../src/gates/build.js');
+const { runAudit } = await import('../src/gates/audit.js');
+const { runCiConfig } = await import('../src/gates/ci-config.js');
+const { runE2e } = await import('../src/gates/e2e.js');
+const { runSecurity } = await import('../src/gates/security.js');
+const { runPerformance } = await import('../src/gates/performance.js');
+
+const { run } = await import('../src/runner.js');
+
+const mockGates = {
+  lint: vi.mocked(runLint),
+  typecheck: vi.mocked(runTypecheck),
+  tests: vi.mocked(runTests),
+  build: vi.mocked(runBuild),
+  audit: vi.mocked(runAudit),
+  'ci-config': vi.mocked(runCiConfig),
+  e2e: vi.mocked(runE2e),
+  security: vi.mocked(runSecurity),
+  performance: vi.mocked(runPerformance),
+};
+
+function passResult(gate: string): GateResult {
+  return { gate: gate as GateResult['gate'], status: 'PASS', duration: 10 };
+}
+
+function warnResult(gate: string): GateResult {
+  return { gate: gate as GateResult['gate'], status: 'WARN', duration: 10 };
+}
+
+function failResult(gate: string): GateResult {
+  return { gate: gate as GateResult['gate'], status: 'FAIL', duration: 10 };
+}
+
+function allPass() {
+  for (const [name, mock] of Object.entries(mockGates)) {
+    mock.mockResolvedValue(passResult(name));
+  }
+}
+
+let reportDir: string;
+
+beforeEach(() => {
+  reportDir = join(tmpdir(), `ats-runner-${randomUUID()}`);
+  mkdirSync(reportDir, { recursive: true });
+  vi.clearAllMocks();
+  allPass();
+});
+
+afterEach(() => {
+  rmSync(reportDir, { recursive: true, force: true });
+});
+
+function baseConfig(overrides: Partial<RunConfig> = {}): RunConfig {
+  return {
+    projectPath: '/tmp/fake',
+    skip: [],
+    only: null,
+    failFast: true,
+    reportDir,
+    includePerf: false,
+    ...overrides,
+  };
+}
+
+describe('runner — gate ordering', () => {
+  it('runs all default gates except performance', async () => {
+    const result = await run(baseConfig());
+    const ran = result.gates.map(g => g.gate);
+    expect(ran).toEqual(['lint', 'typecheck', 'tests', 'build', 'audit', 'ci-config', 'e2e', 'security']);
+    expect(ran).not.toContain('performance');
+  });
+
+  it('includes performance when includePerf is true', async () => {
+    const result = await run(baseConfig({ includePerf: true }));
+    expect(result.gates.map(g => g.gate)).toContain('performance');
+  });
+
+  it('maintains fixed gate order', async () => {
+    const result = await run(baseConfig());
+    const ran = result.gates.map(g => g.gate);
+    const expected = ['lint', 'typecheck', 'tests', 'build', 'audit', 'ci-config', 'e2e', 'security'];
+    expect(ran).toEqual(expected);
+  });
+});
+
+describe('runner — --skip', () => {
+  it('skips a single gate', async () => {
+    const result = await run(baseConfig({ skip: ['lint'] }));
+    expect(result.gates.map(g => g.gate)).not.toContain('lint');
+  });
+
+  it('skips multiple gates', async () => {
+    const result = await run(baseConfig({ skip: ['lint', 'audit', 'e2e'] }));
+    const ran = result.gates.map(g => g.gate);
+    expect(ran).not.toContain('lint');
+    expect(ran).not.toContain('audit');
+    expect(ran).not.toContain('e2e');
+  });
+
+  it('skipping all gates returns empty results with PASS verdict', async () => {
+    const allGates = gateNames.filter(g => g !== 'performance') as RunConfig['skip'];
+    const result = await run(baseConfig({ skip: allGates }));
+    expect(result.gates).toHaveLength(0);
+    expect(result.verdict).toBe('PASS');
+  });
+});
+
+describe('runner — --only', () => {
+  it('runs only specified gates', async () => {
+    const result = await run(baseConfig({ only: ['lint', 'typecheck'] }));
+    expect(result.gates.map(g => g.gate)).toEqual(['lint', 'typecheck']);
+  });
+
+  it('only a single gate', async () => {
+    const result = await run(baseConfig({ only: ['tests'] }));
+    expect(result.gates).toHaveLength(1);
+    expect(result.gates[0].gate).toBe('tests');
+  });
+
+  it('--only + --skip: skip takes precedence', async () => {
+    const result = await run(baseConfig({ only: ['lint', 'typecheck', 'tests'], skip: ['typecheck'] }));
+    const ran = result.gates.map(g => g.gate);
+    expect(ran).toContain('lint');
+    expect(ran).not.toContain('typecheck');
+    expect(ran).toContain('tests');
+  });
+
+  it('--only with performance gate requires includePerf', async () => {
+    const result = await run(baseConfig({ only: ['performance'], includePerf: false }));
+    expect(result.gates).toHaveLength(0);
+  });
+
+  it('--only with performance gate and includePerf runs it', async () => {
+    const result = await run(baseConfig({ only: ['performance'], includePerf: true }));
+    expect(result.gates.map(g => g.gate)).toContain('performance');
+  });
+});
+
+describe('runner — fail-fast', () => {
+  it('stops after first FAIL when failFast is true', async () => {
+    mockGates.lint.mockResolvedValue(failResult('lint'));
+
+    const result = await run(baseConfig({ failFast: true }));
+    expect(result.gates).toHaveLength(1);
+    expect(result.gates[0].gate).toBe('lint');
+    expect(mockGates.typecheck).not.toHaveBeenCalled();
+  });
+
+  it('continues after FAIL when failFast is false', async () => {
+    mockGates.lint.mockResolvedValue(failResult('lint'));
+
+    const result = await run(baseConfig({ failFast: false }));
+    expect(result.gates.length).toBeGreaterThan(1);
+    expect(result.gates[0].status).toBe('FAIL');
+    expect(mockGates.typecheck).toHaveBeenCalled();
+  });
+
+  it('stops at the failing gate, not before', async () => {
+    mockGates.tests.mockResolvedValue(failResult('tests'));
+
+    const result = await run(baseConfig({ failFast: true }));
+    const ran = result.gates.map(g => g.gate);
+    expect(ran).toContain('lint');
+    expect(ran).toContain('typecheck');
+    expect(ran).toContain('tests');
+    expect(ran).not.toContain('build');
+  });
+
+  it('WARN does not trigger fail-fast', async () => {
+    mockGates.lint.mockResolvedValue(warnResult('lint'));
+
+    const result = await run(baseConfig({ failFast: true }));
+    expect(result.gates.length).toBeGreaterThan(1);
+    expect(mockGates.typecheck).toHaveBeenCalled();
+  });
+});
+
+describe('runner — verdict logic', () => {
+  it('returns PASS when all gates pass', async () => {
+    const result = await run(baseConfig());
+    expect(result.verdict).toBe('PASS');
+  });
+
+  it('returns CONDITIONAL_PASS when any gate warns', async () => {
+    mockGates.audit.mockResolvedValue(warnResult('audit'));
+    const result = await run(baseConfig({ failFast: false }));
+    expect(result.verdict).toBe('CONDITIONAL_PASS');
+  });
+
+  it('returns FAIL when any gate fails', async () => {
+    mockGates.typecheck.mockResolvedValue(failResult('typecheck'));
+    const result = await run(baseConfig({ failFast: false }));
+    expect(result.verdict).toBe('FAIL');
+  });
+
+  it('FAIL takes precedence over WARN', async () => {
+    mockGates.lint.mockResolvedValue(warnResult('lint'));
+    mockGates.tests.mockResolvedValue(failResult('tests'));
+    const result = await run(baseConfig({ failFast: false }));
+    expect(result.verdict).toBe('FAIL');
+  });
+
+  it('multiple WARNs still yield CONDITIONAL_PASS', async () => {
+    mockGates.lint.mockResolvedValue(warnResult('lint'));
+    mockGates.audit.mockResolvedValue(warnResult('audit'));
+    const result = await run(baseConfig({ failFast: false }));
+    expect(result.verdict).toBe('CONDITIONAL_PASS');
+  });
+});
+
+describe('runner — run result shape', () => {
+  it('returns durationMs as a non-negative number', async () => {
+    const result = await run(baseConfig());
+    expect(result.durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('returns a valid ISO timestamp', async () => {
+    const result = await run(baseConfig());
+    expect(new Date(result.timestamp).toISOString()).toBe(result.timestamp);
+  });
+
+  it('includes config and context in result', async () => {
+    const config = baseConfig();
+    const result = await run(config);
+    expect(result.config).toBe(config);
+    expect(result.context).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

- **23 runner integration tests** covering gate ordering, `--skip`, `--only`, fail-fast behaviour, verdict logic (PASS / CONDITIONAL_PASS / FAIL), and run result shape
- **11 CLI subprocess tests** covering `--version`, `--help`, `--skip`, `--only`, `--no-fail-fast`, `--report-dir`, and exit codes
- **Bug fix**: typo `options.includePef` → `options.includePerf` in `cli.ts` (was silently breaking `--include-perf` flag)
- Total tests: **125** (up from 91)

## Test plan

- [x] `pnpm test` — 125/125 passing
- [x] `pnpm lint` — zero warnings
- [x] `pnpm typecheck` — zero errors
- [x] `pnpm build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)