### PR TITLE
feat(sprint6e): monorepo-aware gate execution via package.json scripts

### DIFF
--- a/src/detectors/index.ts
+++ b/src/detectors/index.ts
@@ -10,6 +10,17 @@ function detectPackageManager(root: string): ProjectContext['packageManager'] {
   return null;
 }
 
+function readScripts(root: string): Record<string, string> {
+  const pkgPath = join(root, 'package.json');
+  if (!existsSync(pkgPath)) return {};
+  try {
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
+    return pkg.scripts ?? {};
+  } catch {
+    return {};
+  }
+}
+
 function isReact(root: string): boolean {
   const pkgPath = join(root, 'package.json');
   if (!existsSync(pkgPath)) return false;
@@ -52,5 +63,6 @@ export function detectProject(rootPath: string): ProjectContext {
     rootPath,
     types,
     packageManager: detectPackageManager(rootPath),
+    scripts: readScripts(rootPath),
   };
 }

--- a/src/gates/lint.ts
+++ b/src/gates/lint.ts
@@ -25,6 +25,12 @@ function eslintCmd(ctx: ProjectContext): [string, string[]] {
   return ['npx', ['eslint', '.']];
 }
 
+function lintScriptCmd(ctx: ProjectContext): [string, string[]] {
+  if (ctx.packageManager === 'pnpm') return ['pnpm', ['run', 'lint']];
+  if (ctx.packageManager === 'yarn') return ['yarn', ['lint']];
+  return ['npm', ['run', 'lint']];
+}
+
 function hasRuffConfig(rootPath: string): boolean {
   if (existsSync(join(rootPath, 'ruff.toml')) || existsSync(join(rootPath, '.ruff.toml'))) return true;
   const pyproject = join(rootPath, 'pyproject.toml');
@@ -37,7 +43,10 @@ function hasRuffConfig(rootPath: string): boolean {
 }
 
 async function runEslint(ctx: ProjectContext): Promise<GateResult> {
-  if (!hasEslintConfig(ctx.rootPath)) {
+  const hasScript = Boolean(ctx.scripts.lint);
+  const hasConfig = hasEslintConfig(ctx.rootPath);
+
+  if (!hasScript && !hasConfig) {
     return {
       gate: 'lint',
       status: 'SKIP',
@@ -47,7 +56,7 @@ async function runEslint(ctx: ProjectContext): Promise<GateResult> {
   }
 
   const start = Date.now();
-  const [cmd, args] = eslintCmd(ctx);
+  const [cmd, args] = hasScript ? lintScriptCmd(ctx) : eslintCmd(ctx);
   try {
     const result = await execa(cmd, args, { cwd: ctx.rootPath, reject: false });
     const duration = Date.now() - start;

--- a/src/gates/typecheck.ts
+++ b/src/gates/typecheck.ts
@@ -9,6 +9,12 @@ function tscCmd(ctx: ProjectContext): [string, string[]] {
   return ['npx', ['tsc', '--noEmit']];
 }
 
+function typecheckScriptCmd(ctx: ProjectContext): [string, string[]] {
+  if (ctx.packageManager === 'pnpm') return ['pnpm', ['run', 'typecheck']];
+  if (ctx.packageManager === 'yarn') return ['yarn', ['typecheck']];
+  return ['npm', ['run', 'typecheck']];
+}
+
 function hasMypyConfig(rootPath: string): boolean {
   if (existsSync(join(rootPath, 'mypy.ini')) || existsSync(join(rootPath, '.mypy.ini'))) return true;
   const pyproject = join(rootPath, 'pyproject.toml');
@@ -69,7 +75,10 @@ export async function runTypecheck(ctx: ProjectContext): Promise<GateResult> {
   if (ctx.types.includes('python')) return runMypy(ctx);
   if (!isNode) return { gate: 'typecheck', status: 'SKIP', duration: 0 };
 
-  if (!existsSync(join(ctx.rootPath, 'tsconfig.json'))) {
+  const hasScript = Boolean(ctx.scripts.typecheck);
+  const hasTsconfig = existsSync(join(ctx.rootPath, 'tsconfig.json'));
+
+  if (!hasScript && !hasTsconfig) {
     return {
       gate: 'typecheck',
       status: 'SKIP',
@@ -79,7 +88,7 @@ export async function runTypecheck(ctx: ProjectContext): Promise<GateResult> {
   }
 
   const start = Date.now();
-  const [cmd, args] = tscCmd(ctx);
+  const [cmd, args] = hasScript ? typecheckScriptCmd(ctx) : tscCmd(ctx);
   try {
     const result = await execa(cmd, args, { cwd: ctx.rootPath, reject: false });
     const duration = Date.now() - start;

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,7 @@ export interface ProjectContext {
   rootPath: string;
   types: ProjectType[];
   packageManager: 'npm' | 'pnpm' | 'yarn' | null;
+  scripts: Record<string, string>;
 }
 
 export interface RunConfig {

--- a/tests/detectors.test.ts
+++ b/tests/detectors.test.ts
@@ -73,4 +73,27 @@ describe('detectProject', () => {
     expect(ctx.types).toHaveLength(0);
     expect(ctx.packageManager).toBeNull();
   });
+
+  it('populates scripts from package.json', () => {
+    const dir = makeTemp();
+    writeFileSync(
+      join(dir, 'package.json'),
+      JSON.stringify({ scripts: { lint: 'eslint .', typecheck: 'tsc --noEmit', test: 'vitest' } }),
+    );
+    const ctx = detectProject(dir);
+    expect(ctx.scripts).toEqual({ lint: 'eslint .', typecheck: 'tsc --noEmit', test: 'vitest' });
+  });
+
+  it('returns empty scripts when no package.json', () => {
+    const dir = makeTemp();
+    const ctx = detectProject(dir);
+    expect(ctx.scripts).toEqual({});
+  });
+
+  it('returns empty scripts when package.json has no scripts field', () => {
+    const dir = makeTemp();
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'test' }));
+    const ctx = detectProject(dir);
+    expect(ctx.scripts).toEqual({});
+  });
 });

--- a/tests/gates/audit.test.ts
+++ b/tests/gates/audit.test.ts
@@ -21,7 +21,7 @@ function makeTemp(): string {
 }
 
 function ctx(rootPath: string): ProjectContext {
-  return { rootPath, types: ['nodejs'], packageManager: 'npm' };
+  return { rootPath, types: ['nodejs'], packageManager: 'npm', scripts: {} };
 }
 
 function auditJson(high = 0, critical = 0, moderate = 0): string {
@@ -40,7 +40,7 @@ afterEach(() => {
 describe('runAudit — SKIP', () => {
   it('SKIPs for non-Node projects', async () => {
     const dir = makeTemp();
-    const result = await runAudit({ rootPath: dir, types: ['docker'], packageManager: null });
+    const result = await runAudit({ rootPath: dir, types: ['docker'], packageManager: null, scripts: {} });
     expect(result.status).toBe('SKIP');
     expect(mockExeca).not.toHaveBeenCalled();
   });

--- a/tests/gates/build.test.ts
+++ b/tests/gates/build.test.ts
@@ -21,7 +21,7 @@ function makeTemp(): string {
 }
 
 function ctx(rootPath: string, pm: ProjectContext['packageManager'] = 'npm'): ProjectContext {
-  return { rootPath, types: ['nodejs'], packageManager: pm };
+  return { rootPath, types: ['nodejs'], packageManager: pm, scripts: {} };
 }
 
 afterEach(() => {
@@ -32,7 +32,7 @@ afterEach(() => {
 describe('runBuild — SKIP', () => {
   it('SKIPs for non-Node projects', async () => {
     const dir = makeTemp();
-    const result = await runBuild({ rootPath: dir, types: ['python'], packageManager: null });
+    const result = await runBuild({ rootPath: dir, types: ['python'], packageManager: null, scripts: {} });
     expect(result.status).toBe('SKIP');
     expect(mockExeca).not.toHaveBeenCalled();
   });

--- a/tests/gates/ci-config.test.ts
+++ b/tests/gates/ci-config.test.ts
@@ -15,7 +15,7 @@ function makeTemp(): string {
 }
 
 function ctx(rootPath: string): ProjectContext {
-  return { rootPath, types: ['nodejs'], packageManager: 'pnpm' };
+  return { rootPath, types: ['nodejs'], packageManager: 'pnpm', scripts: {} };
 }
 
 const FULL_WORKFLOW = `

--- a/tests/gates/docker-build.test.ts
+++ b/tests/gates/docker-build.test.ts
@@ -21,7 +21,7 @@ function makeTemp(): string {
 }
 
 function dockerCtx(rootPath: string): ProjectContext {
-  return { rootPath, types: ['docker'], packageManager: null };
+  return { rootPath, types: ['docker'], packageManager: null, scripts: {} };
 }
 
 afterEach(() => {
@@ -32,7 +32,7 @@ afterEach(() => {
 describe('runBuild (docker) — SKIP', () => {
   it('SKIPs nodejs project', async () => {
     const dir = makeTemp();
-    const result = await runBuild({ rootPath: dir, types: ['nodejs'], packageManager: 'npm' });
+    const result = await runBuild({ rootPath: dir, types: ['nodejs'], packageManager: 'npm', scripts: {} });
     // nodejs project with no build script should SKIP
     expect(result.status).toBe('SKIP');
     expect(mockExeca).not.toHaveBeenCalled();

--- a/tests/gates/e2e.test.ts
+++ b/tests/gates/e2e.test.ts
@@ -21,7 +21,7 @@ function makeTemp(): string {
 }
 
 function webCtx(rootPath: string): ProjectContext {
-  return { rootPath, types: ['nodejs'], packageManager: 'npm' };
+  return { rootPath, types: ['nodejs'], packageManager: 'npm', scripts: {} };
 }
 
 afterEach(() => {
@@ -32,7 +32,7 @@ afterEach(() => {
 describe('runE2e — SKIP', () => {
   it('SKIPs python project (not web)', async () => {
     const dir = makeTemp();
-    const result = await runE2e({ rootPath: dir, types: ['python'], packageManager: null });
+    const result = await runE2e({ rootPath: dir, types: ['python'], packageManager: null, scripts: {} });
     expect(result.status).toBe('SKIP');
     expect(mockExeca).not.toHaveBeenCalled();
   });

--- a/tests/gates/lint.test.ts
+++ b/tests/gates/lint.test.ts
@@ -20,8 +20,12 @@ function makeTemp(): string {
   return tempDir;
 }
 
-function ctx(rootPath: string, pm: ProjectContext['packageManager'] = 'npm'): ProjectContext {
-  return { rootPath, types: ['nodejs'], packageManager: pm };
+function ctx(
+  rootPath: string,
+  pm: ProjectContext['packageManager'] = 'npm',
+  scripts: Record<string, string> = {},
+): ProjectContext {
+  return { rootPath, types: ['nodejs'], packageManager: pm, scripts };
 }
 
 afterEach(() => {
@@ -40,7 +44,7 @@ describe('runLint — SKIP', () => {
 
   it('SKIPs for non-Node projects', async () => {
     const dir = makeTemp();
-    const result = await runLint({ rootPath: dir, types: ['python'], packageManager: null });
+    const result = await runLint({ rootPath: dir, types: ['python'], packageManager: null, scripts: {} });
     expect(result.status).toBe('SKIP');
     expect(mockExeca).not.toHaveBeenCalled();
   });
@@ -94,5 +98,57 @@ describe('runLint — FAIL', () => {
 
     await runLint(ctx(dir, 'pnpm'));
     expect(mockExeca).toHaveBeenCalledWith('pnpm', expect.arrayContaining(['exec', 'eslint']), expect.any(Object));
+  });
+});
+
+describe('runLint — script-first (monorepo)', () => {
+  it('PASSes via npm run lint when scripts.lint present and exits 0', async () => {
+    const dir = makeTemp();
+    mockExeca.mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' } as never);
+
+    const result = await runLint(ctx(dir, 'npm', { lint: 'eslint .' }));
+    expect(result.status).toBe('PASS');
+    expect(mockExeca).toHaveBeenCalledWith('npm', ['run', 'lint'], expect.any(Object));
+  });
+
+  it('FAILs via npm run lint when exits 1', async () => {
+    const dir = makeTemp();
+    mockExeca.mockResolvedValue({
+      exitCode: 1,
+      stdout: "1:1  error  'x' is defined but never used",
+      stderr: '',
+    } as never);
+
+    const result = await runLint(ctx(dir, 'npm', { lint: 'eslint .' }));
+    expect(result.status).toBe('FAIL');
+  });
+
+  it('WARNs via npm run lint when exits 0 with warnings', async () => {
+    const dir = makeTemp();
+    mockExeca.mockResolvedValue({
+      exitCode: 0,
+      stdout: '1 warning found',
+      stderr: '',
+    } as never);
+
+    const result = await runLint(ctx(dir, 'npm', { lint: 'eslint .' }));
+    expect(result.status).toBe('WARN');
+  });
+
+  it('uses pnpm run lint when packageManager is pnpm', async () => {
+    const dir = makeTemp();
+    mockExeca.mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' } as never);
+
+    await runLint(ctx(dir, 'pnpm', { lint: 'eslint .' }));
+    expect(mockExeca).toHaveBeenCalledWith('pnpm', ['run', 'lint'], expect.any(Object));
+  });
+
+  it('script takes precedence over missing eslint config', async () => {
+    const dir = makeTemp();
+    mockExeca.mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' } as never);
+
+    const result = await runLint(ctx(dir, 'npm', { lint: 'eslint .' }));
+    expect(result.status).toBe('PASS');
+    expect(mockExeca).toHaveBeenCalled();
   });
 });

--- a/tests/gates/performance.test.ts
+++ b/tests/gates/performance.test.ts
@@ -21,7 +21,7 @@ function makeTemp(): string {
 }
 
 function webCtx(rootPath: string): ProjectContext {
-  return { rootPath, types: ['nodejs'], packageManager: 'npm' };
+  return { rootPath, types: ['nodejs'], packageManager: 'npm', scripts: {} };
 }
 
 afterEach(() => {
@@ -32,7 +32,7 @@ afterEach(() => {
 describe('runPerformance — SKIP', () => {
   it('SKIPs python project (not web)', async () => {
     const dir = makeTemp();
-    const result = await runPerformance({ rootPath: dir, types: ['python'], packageManager: null });
+    const result = await runPerformance({ rootPath: dir, types: ['python'], packageManager: null, scripts: {} });
     expect(result.status).toBe('SKIP');
     expect(mockExeca).not.toHaveBeenCalled();
   });

--- a/tests/gates/python-audit.test.ts
+++ b/tests/gates/python-audit.test.ts
@@ -21,7 +21,7 @@ function makeTemp(): string {
 }
 
 function pyCtx(rootPath: string): ProjectContext {
-  return { rootPath, types: ['python'], packageManager: null };
+  return { rootPath, types: ['python'], packageManager: null, scripts: {} };
 }
 
 afterEach(() => {
@@ -32,7 +32,7 @@ afterEach(() => {
 describe('runAudit (python) — SKIP', () => {
   it('SKIPs docker-only project', async () => {
     const dir = makeTemp();
-    const result = await runAudit({ rootPath: dir, types: ['docker'], packageManager: null });
+    const result = await runAudit({ rootPath: dir, types: ['docker'], packageManager: null, scripts: {} });
     expect(result.status).toBe('SKIP');
     expect(mockExeca).not.toHaveBeenCalled();
   });

--- a/tests/gates/python-lint.test.ts
+++ b/tests/gates/python-lint.test.ts
@@ -21,7 +21,7 @@ function makeTemp(): string {
 }
 
 function pyCtx(rootPath: string): ProjectContext {
-  return { rootPath, types: ['python'], packageManager: null };
+  return { rootPath, types: ['python'], packageManager: null, scripts: {} };
 }
 
 afterEach(() => {
@@ -39,7 +39,7 @@ describe('runLint (python) — SKIP', () => {
 
   it('SKIPs docker-only project', async () => {
     const dir = makeTemp();
-    const result = await runLint({ rootPath: dir, types: ['docker'], packageManager: null });
+    const result = await runLint({ rootPath: dir, types: ['docker'], packageManager: null, scripts: {} });
     expect(result.status).toBe('SKIP');
     expect(mockExeca).not.toHaveBeenCalled();
   });

--- a/tests/gates/python-tests.test.ts
+++ b/tests/gates/python-tests.test.ts
@@ -21,7 +21,7 @@ function makeTemp(): string {
 }
 
 function pyCtx(rootPath: string): ProjectContext {
-  return { rootPath, types: ['python'], packageManager: null };
+  return { rootPath, types: ['python'], packageManager: null, scripts: {} };
 }
 
 afterEach(() => {
@@ -32,7 +32,7 @@ afterEach(() => {
 describe('runTests (python) — SKIP', () => {
   it('SKIPs docker-only project', async () => {
     const dir = makeTemp();
-    const result = await runTests({ rootPath: dir, types: ['docker'], packageManager: null });
+    const result = await runTests({ rootPath: dir, types: ['docker'], packageManager: null, scripts: {} });
     expect(result.status).toBe('SKIP');
     expect(mockExeca).not.toHaveBeenCalled();
   });

--- a/tests/gates/python-typecheck.test.ts
+++ b/tests/gates/python-typecheck.test.ts
@@ -21,7 +21,7 @@ function makeTemp(): string {
 }
 
 function pyCtx(rootPath: string): ProjectContext {
-  return { rootPath, types: ['python'], packageManager: null };
+  return { rootPath, types: ['python'], packageManager: null, scripts: {} };
 }
 
 afterEach(() => {
@@ -39,7 +39,7 @@ describe('runTypecheck (python) — SKIP', () => {
 
   it('SKIPs docker-only project', async () => {
     const dir = makeTemp();
-    const result = await runTypecheck({ rootPath: dir, types: ['docker'], packageManager: null });
+    const result = await runTypecheck({ rootPath: dir, types: ['docker'], packageManager: null, scripts: {} });
     expect(result.status).toBe('SKIP');
     expect(mockExeca).not.toHaveBeenCalled();
   });

--- a/tests/gates/security.test.ts
+++ b/tests/gates/security.test.ts
@@ -21,11 +21,11 @@ function makeTemp(): string {
 }
 
 function pyCtx(rootPath: string): ProjectContext {
-  return { rootPath, types: ['python'], packageManager: null };
+  return { rootPath, types: ['python'], packageManager: null, scripts: {} };
 }
 
 function nodeCtx(rootPath: string): ProjectContext {
-  return { rootPath, types: ['nodejs'], packageManager: 'npm' };
+  return { rootPath, types: ['nodejs'], packageManager: 'npm', scripts: {} };
 }
 
 afterEach(() => {
@@ -36,7 +36,7 @@ afterEach(() => {
 describe('runSecurity — SKIP', () => {
   it('SKIPs docker-only project', async () => {
     const dir = makeTemp();
-    const result = await runSecurity({ rootPath: dir, types: ['docker'], packageManager: null });
+    const result = await runSecurity({ rootPath: dir, types: ['docker'], packageManager: null, scripts: {} });
     expect(result.status).toBe('SKIP');
     expect(mockExeca).not.toHaveBeenCalled();
   });

--- a/tests/gates/tests.test.ts
+++ b/tests/gates/tests.test.ts
@@ -21,7 +21,7 @@ function makeTemp(): string {
 }
 
 function ctx(rootPath: string): ProjectContext {
-  return { rootPath, types: ['nodejs'], packageManager: 'pnpm' };
+  return { rootPath, types: ['nodejs'], packageManager: 'pnpm', scripts: {} };
 }
 
 afterEach(() => {
@@ -32,7 +32,7 @@ afterEach(() => {
 describe('runTests — SKIP', () => {
   it('SKIPs for non-Node projects', async () => {
     const dir = makeTemp();
-    const result = await runTests({ rootPath: dir, types: ['docker'], packageManager: null });
+    const result = await runTests({ rootPath: dir, types: ['docker'], packageManager: null, scripts: {} });
     expect(result.status).toBe('SKIP');
     expect(mockExeca).not.toHaveBeenCalled();
   });

--- a/tests/gates/typecheck.test.ts
+++ b/tests/gates/typecheck.test.ts
@@ -20,8 +20,8 @@ function makeTemp(): string {
   return tempDir;
 }
 
-function ctx(rootPath: string): ProjectContext {
-  return { rootPath, types: ['nodejs'], packageManager: 'pnpm' };
+function ctx(rootPath: string, scripts: Record<string, string> = {}): ProjectContext {
+  return { rootPath, types: ['nodejs'], packageManager: 'pnpm', scripts };
 }
 
 afterEach(() => {
@@ -32,7 +32,7 @@ afterEach(() => {
 describe('runTypecheck — SKIP', () => {
   it('SKIPs for non-Node projects', async () => {
     const dir = makeTemp();
-    const result = await runTypecheck({ rootPath: dir, types: ['python'], packageManager: null });
+    const result = await runTypecheck({ rootPath: dir, types: ['python'], packageManager: null, scripts: {} });
     expect(result.status).toBe('SKIP');
     expect(mockExeca).not.toHaveBeenCalled();
   });
@@ -55,6 +55,39 @@ describe('runTypecheck — PASS', () => {
     const result = await runTypecheck(ctx(dir));
     expect(result.status).toBe('PASS');
     expect(result.gate).toBe('typecheck');
+  });
+});
+
+describe('runTypecheck — script-first (monorepo)', () => {
+  it('PASSes via pnpm run typecheck when scripts.typecheck present and exits 0', async () => {
+    const dir = makeTemp();
+    mockExeca.mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' } as never);
+
+    const result = await runTypecheck(ctx(dir, { typecheck: 'tsc --noEmit' }));
+    expect(result.status).toBe('PASS');
+    expect(mockExeca).toHaveBeenCalledWith('pnpm', ['run', 'typecheck'], expect.any(Object));
+  });
+
+  it('FAILs via script when exits 1', async () => {
+    const dir = makeTemp();
+    mockExeca.mockResolvedValue({
+      exitCode: 1,
+      stdout: "src/foo.ts(1,5): error TS2304: Cannot find name 'x'.",
+      stderr: '',
+    } as never);
+
+    const result = await runTypecheck(ctx(dir, { typecheck: 'tsc --noEmit' }));
+    expect(result.status).toBe('FAIL');
+    expect(result.errors).toHaveLength(1);
+  });
+
+  it('script takes precedence over missing tsconfig', async () => {
+    const dir = makeTemp();
+    mockExeca.mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' } as never);
+
+    const result = await runTypecheck(ctx(dir, { typecheck: 'tsc --noEmit' }));
+    expect(result.status).toBe('PASS');
+    expect(mockExeca).toHaveBeenCalled();
   });
 });
 

--- a/tests/reporters/html.test.ts
+++ b/tests/reporters/html.test.ts
@@ -25,7 +25,7 @@ function makeResult(overrides: Partial<RunResult> = {}): RunResult {
       reportDir: tempDir,
       includePerf: false,
     },
-    context: { rootPath: '/tmp/my-project', types: ['nodejs'], packageManager: 'npm' },
+    context: { rootPath: '/tmp/my-project', types: ['nodejs'], packageManager: 'npm', scripts: {} },
     gates: [
       { gate: 'lint', status: 'PASS', duration: 100 },
       { gate: 'typecheck', status: 'FAIL', duration: 200, errors: ['src/x.ts:1 error TS2345'], fix: 'Run: npx tsc --noEmit' },

--- a/tests/reporters/json.test.ts
+++ b/tests/reporters/json.test.ts
@@ -25,7 +25,7 @@ function makeResult(overrides: Partial<RunResult> = {}): RunResult {
       reportDir: tempDir,
       includePerf: false,
     },
-    context: { rootPath: '/tmp/my-project', types: ['nodejs'], packageManager: 'npm' },
+    context: { rootPath: '/tmp/my-project', types: ['nodejs'], packageManager: 'npm', scripts: {} },
     gates: [
       { gate: 'lint', status: 'PASS', duration: 123 },
       { gate: 'typecheck', status: 'FAIL', duration: 456, errors: ['src/index.ts:1 error TS2345'] },


### PR DESCRIPTION
## Summary

- Gates now prefer `package.json` scripts over config-file detection for lint and typecheck
- If `scripts.lint` / `scripts.typecheck` exists in `package.json`, ATS runs `npm run lint` / `npm run typecheck` (or pnpm/yarn equivalent) and trusts the exit code
- Config-file detection (`eslint.config.js`, `tsconfig.json`) becomes the fallback for projects with no scripts
- Fixes silent SKIP on lint/typecheck for monorepos like budget-manager where configs live in `client/` / `server/` subdirectories but root `package.json` exposes delegating scripts

## Changes

- `src/types.ts` — added `scripts: Record<string, string>` to `ProjectContext`
- `src/detectors/index.ts` — added `readScripts()` helper, populated in `detectProject()`
- `src/gates/lint.ts` — script-first logic with eslint config as fallback
- `src/gates/typecheck.ts` — script-first logic with tsconfig as fallback
- 11 new tests (5 lint script-first, 3 typecheck script-first, 3 detector)
- All existing `ProjectContext` literals updated with `scripts: {}` (102 tests pass)

## Test plan

- [x] `pnpm test` — 102 tests, all passing
- [x] `pnpm typecheck` — zero errors
- [x] `pnpm lint` — zero errors
- [ ] Dogfood against budget-manager after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)