### PR TITLE
chore(release): bump to v1.2.0, document watch command

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ pnpm link --global
 ats run <project-path>
 ```
 
+### Watch mode
+
+Re-runs gates automatically when files change:
+
+```bash
+ats watch <project-path>
+```
+
+Uses debounced file watching — gates re-run 500ms after the last change.
+
 ### Options
 
 | Flag | Description |
@@ -136,7 +146,7 @@ git clone https://github.com/adamwinuk-lgtm/automated-testing-suite
 cd automated-testing-suite
 pnpm install
 pnpm dev          # watch mode
-pnpm test         # vitest (91 tests)
+pnpm test         # vitest (143 tests)
 pnpm build        # compile to dist/
 pnpm lint
 pnpm typecheck

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "automated-testing-suite",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Multi-language quality gate CLI — lint, typecheck, tests, build, audit, security, e2e, and performance gates for Node.js, Python, React, and Docker projects",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- Bumps version from `1.1.0` → `1.2.0` for npm publish
- Documents `ats watch <path>` command in README (added in sprint 6)
- Corrects test count in README (143, was 91)

## Test plan

- [ ] `pnpm build` succeeds
- [ ] `pnpm test` passes (143 tests)
- [ ] `npm publish --dry-run` from `dist/` shows correct package contents

🤖 Generated with [Claude Code](https://claude.com/claude-code)