### PR TITLE
feat(audit): monorepo workspace scanning

### DIFF
--- a/src/gates/audit.ts
+++ b/src/gates/audit.ts
@@ -1,4 +1,4 @@
-import { existsSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import { execa } from 'execa';
 import type { GateResult, ProjectContext } from '../types.js';
@@ -98,6 +98,78 @@ function auditCmd(ctx: ProjectContext): [string, string[]] {
   return ['npm', ['audit', '--json']];
 }
 
+function expandGlobPattern(rootPath: string, pattern: string): string[] {
+  // Handle simple single-level globs like "packages/*" or "apps/*"
+  // Strip leading ./ if present
+  const normalized = pattern.replace(/^\.\//, '');
+  const starIdx = normalized.indexOf('*');
+  if (starIdx === -1) {
+    const full = join(rootPath, normalized);
+    return existsSync(join(full, 'package.json')) ? [full] : [];
+  }
+  const base = normalized.slice(0, starIdx).replace(/\/$/, '');
+  const baseDir = join(rootPath, base);
+  if (!existsSync(baseDir)) return [];
+  try {
+    return readdirSync(baseDir)
+      .map((entry) => join(baseDir, entry))
+      .filter((p) => {
+        try { return statSync(p).isDirectory() && existsSync(join(p, 'package.json')); }
+        catch { return false; }
+      });
+  } catch {
+    return [];
+  }
+}
+
+function resolveWorkspacePackages(rootPath: string): string[] {
+  const results: string[] = [];
+
+  // pnpm-workspace.yaml
+  const pnpmWs = join(rootPath, 'pnpm-workspace.yaml');
+  if (existsSync(pnpmWs)) {
+    try {
+      const content = readFileSync(pnpmWs, 'utf8');
+      // Extract quoted/unquoted list items under the "packages:" key
+      const matches = content.match(/^\s+-\s+['"]?([^'"#\n]+?)['"]?\s*$/gm) ?? [];
+      for (const line of matches) {
+        const pattern = line.replace(/^\s+-\s+['"]?/, '').replace(/['"]?\s*$/, '').trim();
+        if (pattern) results.push(...expandGlobPattern(rootPath, pattern));
+      }
+    } catch {
+      // unreadable — skip
+    }
+  }
+
+  // package.json workspaces field (npm/yarn style)
+  const pkgJson = join(rootPath, 'package.json');
+  if (existsSync(pkgJson)) {
+    try {
+      const pkg = JSON.parse(readFileSync(pkgJson, 'utf8')) as { workspaces?: string[] | { packages?: string[] } };
+      const patterns = Array.isArray(pkg.workspaces)
+        ? pkg.workspaces
+        : pkg.workspaces?.packages ?? [];
+      for (const pattern of patterns) {
+        results.push(...expandGlobPattern(rootPath, pattern));
+      }
+    } catch {
+      // unparseable — skip
+    }
+  }
+
+  // Deduplicate
+  return [...new Set(results)];
+}
+
+async function auditOnePackage(
+  cwd: string,
+  cmd: string,
+  args: string[],
+): Promise<{ vulns: AuditVulns | null; raw: string }> {
+  const result = await execa(cmd, args, { cwd, reject: false });
+  return { vulns: parseVulns(result.stdout), raw: result.stdout || result.stderr };
+}
+
 export async function runAudit(ctx: ProjectContext): Promise<GateResult> {
   if (ctx.types.includes('python')) return runPipAudit(ctx);
   const isNode = ctx.types.includes('nodejs') || ctx.types.includes('react');
@@ -109,46 +181,69 @@ export async function runAudit(ctx: ProjectContext): Promise<GateResult> {
 
   const start = Date.now();
   const [cmd, args] = auditCmd(ctx);
+
+  // Collect all paths to audit: root + any workspace packages
+  const workspaces = resolveWorkspacePackages(ctx.rootPath);
+  const paths = [ctx.rootPath, ...workspaces.filter((p) => p !== ctx.rootPath)];
+
   try {
-    const result = await execa(cmd, args, { cwd: ctx.rootPath, reject: false });
+    const results = await Promise.all(paths.map((p) => auditOnePackage(p, cmd, args)));
     const duration = Date.now() - start;
 
-    const vulns = parseVulns(result.stdout);
-
-    if (!vulns) {
-      // Command ran but output isn't parseable JSON — treat as WARN
+    const unparseable = results.filter((r) => r.vulns === null);
+    if (unparseable.length === results.length) {
       return {
         gate: 'audit',
         status: 'WARN',
         duration,
-        output: result.stdout || result.stderr,
+        output: results[0].raw,
         fix: `Run: ${cmd} audit for details.`,
       };
     }
 
-    if (vulns.critical > 0 || vulns.high > 0) {
+    const totals = results.reduce(
+      (acc, r) => {
+        if (!r.vulns) return acc;
+        return {
+          critical: acc.critical + r.vulns.critical,
+          high: acc.high + r.vulns.high,
+          moderate: acc.moderate + r.vulns.moderate,
+          total: acc.total + r.vulns.total,
+        };
+      },
+      { critical: 0, high: 0, moderate: 0, total: 0 },
+    );
+
+    const pkgLabel = paths.length > 1 ? ` across ${paths.length} packages` : '';
+
+    if (totals.critical > 0 || totals.high > 0) {
       return {
         gate: 'audit',
         status: 'FAIL',
         duration,
         errors: [
-          `${vulns.critical} critical, ${vulns.high} high, ${vulns.moderate} moderate vulnerabilities`,
+          `${totals.critical} critical, ${totals.high} high, ${totals.moderate} moderate vulnerabilities${pkgLabel}`,
         ],
-        fix: `Run: ${cmd === 'npm' ? 'npm' : cmd} audit fix`,
+        fix: `Run: ${cmd} audit fix`,
       };
     }
 
-    if (vulns.moderate > 0) {
+    if (totals.moderate > 0) {
       return {
         gate: 'audit',
         status: 'WARN',
         duration,
-        output: `${vulns.moderate} moderate vulnerabilities found`,
-        fix: `Run: ${cmd === 'npm' ? 'npm' : cmd} audit fix`,
+        output: `${totals.moderate} moderate vulnerabilities found${pkgLabel}`,
+        fix: `Run: ${cmd} audit fix`,
       };
     }
 
-    return { gate: 'audit', status: 'PASS', duration, output: `${vulns.total} vulnerabilities (none high/critical)` };
+    return {
+      gate: 'audit',
+      status: 'PASS',
+      duration,
+      output: `${totals.total} vulnerabilities (none high/critical)${pkgLabel}`,
+    };
   } catch (err) {
     return {
       gate: 'audit',

--- a/tests/gates/audit.test.ts
+++ b/tests/gates/audit.test.ts
@@ -5,6 +5,14 @@ import { tmpdir } from 'node:os';
 import { randomUUID } from 'node:crypto';
 import type { ProjectContext } from '../../src/types.js';
 
+// Helper to create a workspace package directory with a package.json
+function makePackage(root: string, name: string): string {
+  const dir = join(root, name);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'package.json'), JSON.stringify({ name }));
+  return dir;
+}
+
 vi.mock('execa', () => ({ execa: vi.fn() }));
 
 const { execa } = await import('execa');
@@ -98,5 +106,128 @@ describe('runAudit — FAIL', () => {
     const result = await runAudit(ctx(dir));
     expect(result.status).toBe('FAIL');
     expect(result.errors![0]).toMatch(/1 critical/);
+  });
+});
+
+describe('runAudit — monorepo (pnpm-workspace.yaml)', () => {
+  it('audits root + workspace packages and aggregates clean result', async () => {
+    const dir = makeTemp();
+    writeFileSync(join(dir, 'package.json'), '{}');
+    mkdirSync(join(dir, 'packages'), { recursive: true });
+    makePackage(join(dir, 'packages'), 'pkg-a');
+    makePackage(join(dir, 'packages'), 'pkg-b');
+    writeFileSync(
+      join(dir, 'pnpm-workspace.yaml'),
+      "packages:\n  - 'packages/*'\n",
+    );
+    mockExeca.mockResolvedValue({ exitCode: 0, stdout: auditJson(0, 0, 0), stderr: '' } as never);
+
+    const result = await runAudit(ctx(dir));
+    expect(result.status).toBe('PASS');
+    // 3 paths: root + pkg-a + pkg-b
+    expect(mockExeca).toHaveBeenCalledTimes(3);
+    expect(result.output).toMatch(/across 3 packages/);
+  });
+
+  it('FAILs and aggregates vulns across packages', async () => {
+    const dir = makeTemp();
+    writeFileSync(join(dir, 'package.json'), '{}');
+    mkdirSync(join(dir, 'packages'), { recursive: true });
+    makePackage(join(dir, 'packages'), 'pkg-a');
+    writeFileSync(
+      join(dir, 'pnpm-workspace.yaml'),
+      "packages:\n  - 'packages/*'\n",
+    );
+    // root: clean, pkg-a: 1 high
+    mockExeca
+      .mockResolvedValueOnce({ exitCode: 0, stdout: auditJson(0, 0, 0), stderr: '' } as never)
+      .mockResolvedValueOnce({ exitCode: 1, stdout: auditJson(1, 0, 0), stderr: '' } as never);
+
+    const result = await runAudit(ctx(dir));
+    expect(result.status).toBe('FAIL');
+    expect(result.errors![0]).toMatch(/1 high/);
+    expect(result.errors![0]).toMatch(/across 2 packages/);
+  });
+
+  it('WARNs when moderate vulns found in a workspace package', async () => {
+    const dir = makeTemp();
+    writeFileSync(join(dir, 'package.json'), '{}');
+    mkdirSync(join(dir, 'packages'), { recursive: true });
+    makePackage(join(dir, 'packages'), 'pkg-a');
+    writeFileSync(
+      join(dir, 'pnpm-workspace.yaml'),
+      "packages:\n  - 'packages/*'\n",
+    );
+    mockExeca
+      .mockResolvedValueOnce({ exitCode: 0, stdout: auditJson(0, 0, 0), stderr: '' } as never)
+      .mockResolvedValueOnce({ exitCode: 1, stdout: auditJson(0, 0, 2), stderr: '' } as never);
+
+    const result = await runAudit(ctx(dir));
+    expect(result.status).toBe('WARN');
+    expect(result.output).toMatch(/2 moderate/);
+    expect(result.output).toMatch(/across 2 packages/);
+  });
+});
+
+describe('runAudit — monorepo (package.json workspaces)', () => {
+  it('detects npm workspaces array and audits packages', async () => {
+    const dir = makeTemp();
+    mkdirSync(join(dir, 'apps'), { recursive: true });
+    makePackage(join(dir, 'apps'), 'web');
+    writeFileSync(
+      join(dir, 'package.json'),
+      JSON.stringify({ workspaces: ['apps/*'] }),
+    );
+    mockExeca.mockResolvedValue({ exitCode: 0, stdout: auditJson(0, 0, 0), stderr: '' } as never);
+
+    const result = await runAudit(ctx(dir));
+    expect(result.status).toBe('PASS');
+    expect(mockExeca).toHaveBeenCalledTimes(2); // root + apps/web
+    expect(result.output).toMatch(/across 2 packages/);
+  });
+
+  it('detects yarn workspaces.packages object shape', async () => {
+    const dir = makeTemp();
+    mkdirSync(join(dir, 'libs'), { recursive: true });
+    makePackage(join(dir, 'libs'), 'shared');
+    writeFileSync(
+      join(dir, 'package.json'),
+      JSON.stringify({ workspaces: { packages: ['libs/*'] } }),
+    );
+    mockExeca.mockResolvedValue({ exitCode: 0, stdout: auditJson(0, 0, 0), stderr: '' } as never);
+
+    const result = await runAudit(ctx(dir));
+    expect(result.status).toBe('PASS');
+    expect(mockExeca).toHaveBeenCalledTimes(2); // root + libs/shared
+  });
+
+  it('does not double-count root when root is also listed in workspaces', async () => {
+    const dir = makeTemp();
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({ workspaces: ['.'] }));
+    mockExeca.mockResolvedValue({ exitCode: 0, stdout: auditJson(0, 0, 0), stderr: '' } as never);
+
+    const result = await runAudit(ctx(dir));
+    // root resolves to same path — deduped, only 1 audit call
+    expect(result.status).toBe('PASS');
+    expect(mockExeca).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('runAudit — monorepo workspace directories without package.json are skipped', () => {
+  it('ignores non-package directories matching glob', async () => {
+    const dir = makeTemp();
+    writeFileSync(join(dir, 'package.json'), '{}');
+    mkdirSync(join(dir, 'packages', 'not-a-package'), { recursive: true }); // no package.json
+    writeFileSync(
+      join(dir, 'pnpm-workspace.yaml'),
+      "packages:\n  - 'packages/*'\n",
+    );
+    mockExeca.mockResolvedValue({ exitCode: 0, stdout: auditJson(0, 0, 0), stderr: '' } as never);
+
+    const result = await runAudit(ctx(dir));
+    expect(result.status).toBe('PASS');
+    // Only root audited — packages/not-a-package has no package.json
+    expect(mockExeca).toHaveBeenCalledTimes(1);
+    expect(result.output).not.toMatch(/across/);
   });
 });


### PR DESCRIPTION
## Summary

- Extends the `audit` gate to detect monorepos via `pnpm-workspace.yaml` or the `workspaces` field in `package.json`
- Expands workspace glob patterns (`packages/*`, `apps/*`, etc.) to real package directories
- Runs `npm/pnpm/yarn audit` in root **and** each workspace package in parallel
- Aggregates vulnerability counts across all packages; output mentions `across N packages` when scanning more than one
- Fixes the known gap: audit gate previously only scanned the repo root

## Supported workspace formats

| Format | Example |
|--------|---------|
| pnpm `pnpm-workspace.yaml` | `packages:\n  - 'packages/*'` |
| npm/yarn `workspaces` array | `"workspaces": ["apps/*"]` |
| yarn `workspaces.packages` | `"workspaces": { "packages": ["libs/*"] }` |

## Test plan

- [ ] 7 new unit tests cover: pnpm workspaces, npm workspaces array, yarn `workspaces.packages`, cross-package vuln aggregation, WARN aggregation, deduplication, and skipping dirs without `package.json`
- [ ] `pnpm test` → 150 tests, all passing
- [ ] `pnpm lint` → clean
- [ ] `pnpm typecheck` → clean
- [ ] `pnpm build` → succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)